### PR TITLE
adjust-elements-size achicar particulas, orbitas y acomodar camara

### DIFF
--- a/New Unity Project/Assets/Prefabs/ElectronPrefab.prefab
+++ b/New Unity Project/Assets/Prefabs/ElectronPrefab.prefab
@@ -31,41 +31,6 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 5a6c98710e1d63e45aaeb2291e435b81, type: 2}
     - target: {fileID: 8844282507547406996, guid: 0052d38cfcc7a2840b3d4144d4b4ece3,
         type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844282507547406996, guid: 0052d38cfcc7a2840b3d4144d4b4ece3,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844282507547406996, guid: 0052d38cfcc7a2840b3d4144d4b4ece3,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844282507547406996, guid: 0052d38cfcc7a2840b3d4144d4b4ece3,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844282507547406996, guid: 0052d38cfcc7a2840b3d4144d4b4ece3,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844282507547406996, guid: 0052d38cfcc7a2840b3d4144d4b4ece3,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844282507547406996, guid: 0052d38cfcc7a2840b3d4144d4b4ece3,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8844282507547406996, guid: 0052d38cfcc7a2840b3d4144d4b4ece3,
-        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}

--- a/New Unity Project/Assets/Prefabs/ParticlePrefab.prefab
+++ b/New Unity Project/Assets/Prefabs/ParticlePrefab.prefab
@@ -30,7 +30,7 @@ Transform:
   m_GameObject: {fileID: 8924188638573327977}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_LocalScale: {x: 0.06, y: 0.06, z: 0.06}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0

--- a/New Unity Project/Assets/Scenes/SampleScene.unity
+++ b/New Unity Project/Assets/Scenes/SampleScene.unity
@@ -7195,7 +7195,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 534669902}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -4.89}
+  m_LocalPosition: {x: 0, y: 2, z: -4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/New Unity Project/Assets/Scripts/Atom.cs
+++ b/New Unity Project/Assets/Scripts/Atom.cs
@@ -30,10 +30,10 @@ public class Atom: MonoBehaviour
 
     private bool allowElectronSpawn = true;
 
-    private Vector3 firstOrbitPosition = new Vector3(1f, 0f, 0f);
+    private Vector3 firstOrbitPosition = new Vector3(0.5f, 0f, 0f);
 
     // lo que aumenta el radio (x) segun cambie de orbita
-    private Vector3 orbitOffset = new Vector3(0.5f, 0f, 0f);
+    private Vector3 orbitOffset = new Vector3(0.2f, 0f, 0f);
 
     private List<Orbit> orbits = new List<Orbit>();
     Orbit lastOrbit;


### PR DESCRIPTION
- Se achican las partículas del átomo (ParticlePrefab) 
- Se acercan las orbitas (firstOrbitPosition, orbitOffset) 
- Se acomoda la cámara para que quede centrada en Y con la grilla de átomos y un poco más cerca en Z