### PR TITLE
move-camera add CameraManager to control camera with mouse and keys

### DIFF
--- a/New Unity Project/Assets/Scenes/SampleScene.unity
+++ b/New Unity Project/Assets/Scenes/SampleScene.unity
@@ -9918,7 +9918,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1807429813}
   m_Direction: 0
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.9865343
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -18119,7 +18119,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -71.52501, y: 0.0000013877378}
+  m_AnchoredPosition: {x: -70.86572, y: 0.0000013877378}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &896579102

--- a/New Unity Project/Assets/Scenes/SampleScene.unity
+++ b/New Unity Project/Assets/Scenes/SampleScene.unity
@@ -9918,7 +9918,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1807429813}
   m_Direction: 0
   m_Value: 0
-  m_Size: 0.9997013
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -11133,6 +11133,7 @@ GameObject:
   - component: {fileID: 534669905}
   - component: {fileID: 534669904}
   - component: {fileID: 534669903}
+  - component: {fileID: 534669906}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -11204,6 +11205,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &534669906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 534669902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 662fbe7901fb2a044bc92c1bfff89f80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &535075232
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18106,7 +18119,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -71.52503, y: 0.0000013877378}
+  m_AnchoredPosition: {x: -71.52501, y: 0.0000013877378}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &896579102

--- a/New Unity Project/Assets/Scripts/Managers/CameraManager.cs
+++ b/New Unity Project/Assets/Scripts/Managers/CameraManager.cs
@@ -1,0 +1,127 @@
+﻿using UnityEngine;
+
+public class CameraManager : MonoBehaviour
+{
+    // Velocidad con la que rota la camara
+    private float turnSpeed = 5000.0f;
+    // Velocidad con la que se panea la camara
+    private float panSpeed = 1500.0f;
+    // Velocidad con la que se hace zoom
+    private float zoomSpeed = 500.0f;
+
+    private Vector3 lastMousePosition;
+    private bool isPanning;
+    private bool isRotating;
+
+    // Velocidad con la que se mueve la camara con el teclado
+    private float moveSpeed = 10.0f;
+
+    void Update()
+    {
+        ManageMouseInput();
+
+        if (isRotating)
+        {
+            RotateCamera();
+        }
+
+        if (isPanning)
+        {
+            PanCamera();
+        }
+
+        ManageKeyboardInput();
+
+        lastMousePosition = Input.mousePosition;
+    }
+
+    /**
+     * Mueve la camara segun WASD
+     */
+    private void ManageKeyboardInput()
+    {
+        //Keyboard commands
+        Vector3 moveDirection = GetDirectionInput();
+        moveDirection = moveDirection * moveSpeed * Time.deltaTime;
+        transform.Translate(moveDirection);
+    }
+
+    /**
+     * Devuelve la direccion hacia donde hay que mover la camara segun WASD
+     */
+    private Vector3 GetDirectionInput()
+    {
+        Vector3 moveDirection = new Vector3();
+        if (Input.GetKey(KeyCode.W))
+        {
+            moveDirection += new Vector3(0, 0, 1);
+        }
+        if (Input.GetKey(KeyCode.S))
+        {
+            moveDirection += new Vector3(0, 0, -1);
+        }
+        if (Input.GetKey(KeyCode.A))
+        {
+            moveDirection += new Vector3(-1, 0, 0);
+        }
+        if (Input.GetKey(KeyCode.D))
+        {
+            moveDirection += new Vector3(1, 0, 0);
+        }
+        return moveDirection;
+    }
+
+    /**
+     * Se fija que hacer si se apretaron los botones de mouse
+     */
+    private void ManageMouseInput()
+    {
+        // Boton derecho del mouse para rotar la camara
+        if (Input.GetMouseButtonDown(1))
+        {
+            lastMousePosition = Input.mousePosition;
+            isRotating = true;
+        }
+
+        // Boton medio del mouse para panear la camara (click en rueda)
+        if (Input.GetMouseButtonDown(2))
+        {
+            lastMousePosition = Input.mousePosition;
+            isPanning = true;
+        }
+
+        // Mueve la camara en Z cuando se mueve la rueda del mouse (zoom)
+        if (Input.GetAxis("Mouse ScrollWheel") != 0)
+        {
+            Vector3 move = zoomSpeed * transform.forward * Input.GetAxis("Mouse ScrollWheel");
+            transform.Translate(move * Time.deltaTime, Space.World);
+        }
+
+        // Deja de rotar/panear al soltar el boton del mouse
+        if (!Input.GetMouseButton(1)) isRotating = false;
+        if (!Input.GetMouseButton(2)) isPanning = false;
+    }
+
+    /**
+     * Mueve la camara en el plano XY
+     */
+    private void PanCamera()
+    {
+        Vector3 pos = Camera.main.ScreenToViewportPoint(Input.mousePosition - lastMousePosition);
+        Vector3 move = new Vector3(-pos.x * panSpeed, -pos.y * panSpeed, 0);
+        transform.Translate(move * Time.deltaTime, Space.Self);
+    }
+
+    /**
+     * Rota la camara sobre su propio eje
+     */
+    private void RotateCamera()
+    {
+        if (lastMousePosition != Input.mousePosition)
+        {
+            Vector3 pos = Camera.main.ScreenToViewportPoint(Input.mousePosition - lastMousePosition) * Time.deltaTime;
+            transform.RotateAround(transform.position, -transform.right, -pos.y * turnSpeed);
+            transform.RotateAround(transform.position, -Vector3.up, pos.x * turnSpeed);
+        }
+    }
+}

--- a/New Unity Project/Assets/Scripts/Managers/CameraManager.cs
+++ b/New Unity Project/Assets/Scripts/Managers/CameraManager.cs
@@ -9,12 +9,22 @@ public class CameraManager : MonoBehaviour
     // Velocidad con la que se hace zoom
     private float zoomSpeed = 500.0f;
 
+    // Posicion y rotacion inicial de la camara
+    private Vector3 initialPosition;
+    private Quaternion initialRotation;
+
     private Vector3 lastMousePosition;
     private bool isPanning;
     private bool isRotating;
 
     // Velocidad con la que se mueve la camara con el teclado
     private float moveSpeed = 10.0f;
+
+    void Start()
+    {
+        initialPosition = transform.position;
+        initialRotation = transform.rotation;
+    }
 
     void Update()
     {
@@ -31,7 +41,6 @@ public class CameraManager : MonoBehaviour
         }
 
         ManageKeyboardInput();
-
         lastMousePosition = Input.mousePosition;
     }
 
@@ -40,7 +49,7 @@ public class CameraManager : MonoBehaviour
      */
     private void ManageKeyboardInput()
     {
-        //Keyboard commands
+        // Keyboard commands
         Vector3 moveDirection = GetDirectionInput();
         moveDirection = moveDirection * moveSpeed * Time.deltaTime;
         transform.Translate(moveDirection);
@@ -67,6 +76,13 @@ public class CameraManager : MonoBehaviour
         if (Input.GetKey(KeyCode.D))
         {
             moveDirection += new Vector3(1, 0, 0);
+        }
+
+        // Resetea camara a la posicion inicial
+        if (Input.GetKey(KeyCode.R))
+        {
+            transform.SetPositionAndRotation(initialPosition, initialRotation);
+            return Vector3.zero;
         }
         return moveDirection;
     }

--- a/New Unity Project/Assets/Scripts/Managers/CameraManager.cs.meta
+++ b/New Unity Project/Assets/Scripts/Managers/CameraManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 662fbe7901fb2a044bc92c1bfff89f80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Controles:
- Botón derecho del mouse: rotar cámara en su propio eje.
- Botón medio del mouse (click ruedita): panear cámara (mover para los costados, arriba y abajo).
- Rueda del mouse: zoom (mover hacia adelante y atrás).
- Teclas WASD: mover cámara hacia adelante, atrás (como el zoom) y a los costados (no rota, panea horizontalmente).

Con el botón izquierdo se pueden seguir seleccionando cosas y usando la interfaz.