### PR TITLE
Diagonales electrones

### DIFF
--- a/New Unity Project/Assets/Scripts/Elements/Atom.cs
+++ b/New Unity Project/Assets/Scripts/Elements/Atom.cs
@@ -112,9 +112,23 @@ public class Atom: MonoBehaviour
             //selecciono el prefab y lo instancio
             GameObject prefab = particlePrefabs[2];
             GameObject spawn = Instantiate<GameObject>(prefab, parent);
-            Orbit newOrbit = OrbitBuilder.BuildOrbit(electronCounter + 1, this, spawn);
-            spawn.transform.localPosition = newOrbit.Position;
+            Orbit orbit = OrbitBuilder.BuildOrbit(electronCounter + 1, this, spawn);
+            if (orbit == null)
+            {
+                Destroy(spawn);
+                return;
+            }
+            spawn.transform.localPosition = orbit.Position;
             electronCounter++;
+            if (electronCounter == 118)
+            {
+                popup.MostrarPopUp("Atención!", "Se alcanzó el límite máximo de electrones para elementos conocidos. (118)");
+            }
+            else if (electronCounter == 280)
+            {
+                allowElectronSpawn = false;
+                popup.MostrarPopUp("Atención!", "Se alcanzó el límite máximo de electrones permitido. (280)");
+            }
         }
         // indica si fue creado con el boton o desde la tabla
         this.fromTabla = fromTabla;

--- a/New Unity Project/Assets/Scripts/Elements/Atom.cs
+++ b/New Unity Project/Assets/Scripts/Elements/Atom.cs
@@ -40,7 +40,6 @@ public class Atom: MonoBehaviour
     private Vector3 orbitOffset = new Vector3(0.2f, 0f, 0f);
 
     private List<Orbit> orbits = new List<Orbit>();
-    Orbit lastOrbit;
 
     private int elementNumber;
 
@@ -108,20 +107,13 @@ public class Atom: MonoBehaviour
     //crear un electron
     public void SpawnElectron(bool fromTabla)
     {
-        // tomo la ultima orbita
-        lastOrbit = orbits.LastOrDefault();
-
-        // si no hay o la ultima esta completa creo otra
-        AddNewOrbitIfLastIsCompleted();
-
         if (allowElectronSpawn)
         {
             //selecciono el prefab y lo instancio
             GameObject prefab = particlePrefabs[2];
             GameObject spawn = Instantiate<GameObject>(prefab, parent);
-            spawn.transform.localPosition = lastOrbit.Position;
-            // agrego a la lista de electrones y aumento contador
-            lastOrbit.AddElectron(spawn);
+            Orbit newOrbit = OrbitBuilder.BuildOrbit(electronCounter + 1, this, spawn);
+            spawn.transform.localPosition = newOrbit.Position;
             electronCounter++;
         }
         // indica si fue creado con el boton o desde la tabla
@@ -134,34 +126,6 @@ public class Atom: MonoBehaviour
     }
 
     /// <summary>
-    /// Agrega una nueva orbita a la lista si es la primera o si la ultima ya esta completa
-    /// </summary>
-    private void AddNewOrbitIfLastIsCompleted()
-    {
-        // crear nueva orbita si la ultima esta completa o si es la primera
-        if (orbits.Count == 0)
-        {
-            // crear primer orbita
-            SpawnOrbit(1, firstOrbitPosition);
-        }
-        else
-        {
-            // verificar si se llego al maximo de electrones en la ultima orbita
-            if (lastOrbit.isCompleted())
-            {
-                int newOrbitNumber = lastOrbit.Number + 1;
-                Vector3 newOrbitPosition = firstOrbitPosition + (orbitOffset * (newOrbitNumber - 1));
-                Orbit orbit = SpawnOrbit(newOrbitNumber, newOrbitPosition);
-                if (orbit == null)
-                {
-                    // se completaron todas las orbitas
-                    allowElectronSpawn = false;
-                }
-            }
-        }
-    }
-
-    /// <summary>
     /// Crea una orbita correspondiente al numero recibido por parametro.
     /// </summary>
     /// <param name="number">Numero de orbita</param>
@@ -170,7 +134,6 @@ public class Atom: MonoBehaviour
     public Orbit SpawnOrbit(int number, Vector3 position)
     {
         OrbitData orbitData = new OrbitData();
-
         try
         {
             orbitData = qryElement.GetOrbitDataByNumber(number);
@@ -194,7 +157,6 @@ public class Atom: MonoBehaviour
         // crea orbita y la agrega al atomo
         Orbit orbit = new Orbit(orbitData.Number, orbitData.Name, orbitData.MaxElectrons, position, circleSpawn);
         orbits.Add(orbit);
-        lastOrbit = orbit;
         return orbit;
     }
     #endregion
@@ -230,21 +192,22 @@ public class Atom: MonoBehaviour
     {
         if (electronCounter > 0 && orbits.Count > 0)
         {
-            GameObject toDelete = lastOrbit.ElectronList.LastOrDefault();
-            if (toDelete != null)
+            OrbitalAndPeriodStruct orbitalAndPeriod = Orbital.GetOrbitalAndPeriod(electronCounter);
+            Orbit orbit = GetOrbit(orbitalAndPeriod.Period);
+            ElectronSubshell electronSubshell = orbit.GetElectronSubshell(orbitalAndPeriod.Orbital.Name);
+
+            GameObject toDelete = electronSubshell.RemoveLastElectron();
+            Destroy(toDelete);
+
+            if (orbitalAndPeriod.Orbital.Name.Equals(Orbital.GetOrbitalS.Name) && electronSubshell.ElectronList.Count == 0)
             {
-                Destroy(toDelete);
-                lastOrbit.RemoveLastElectron();
-                if(lastOrbit.ElectronList.Count == 0)
-                {
-                    // si la orbita se queda sin electrones la elimino y tomo la anterior como ultima
-                    Destroy(lastOrbit.OrbitCircle);
-                    orbits.Remove(lastOrbit);
-                    lastOrbit = orbits.LastOrDefault();
-                }
-                electronCounter--;
-                allowElectronSpawn = true;
+                // si la orbita se queda sin electrones la elimino
+                Destroy(orbit.OrbitCircle);
+                orbits.Remove(orbit);
+                Debug.Log(orbits.Count);
             }
+            electronCounter--;
+            allowElectronSpawn = true;
         }
         UpdateElement(protonCounter, neutronCounter, electronCounter);
     }
@@ -405,6 +368,19 @@ public class Atom: MonoBehaviour
     void OnDestroy()
     {
         Destroy(gameObject);
+    }
+
+    public Orbit GetOrbit(int number)
+    {
+        foreach (Orbit orbit in orbits)
+        {
+            if (orbit.Number == number)
+            {
+                return orbit;
+            }
+        }
+
+        return null;
     }
 
     #region crear desde tabla periodica

--- a/New Unity Project/Assets/Scripts/Elements/Builders.meta
+++ b/New Unity Project/Assets/Scripts/Elements/Builders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 03022157a3f2c614ebab04bfc98da3e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/Elements/Builders/OrbitBuilder.cs
+++ b/New Unity Project/Assets/Scripts/Elements/Builders/OrbitBuilder.cs
@@ -17,12 +17,14 @@ public class OrbitBuilder
             Orbital orbital = orbitalAndPeriod.Orbital;
             int period = orbitalAndPeriod.Period;
 
-            int position = Math.Min(electronNumber, orbital.MaxElectrons);
-
             Orbit orbit = atom.GetOrbit(period);
             if (orbit == null)
             {
                 orbit = CreateOrbit(atom, period);
+                if (orbit == null)
+                {
+                    return null;
+                }
             }
 
             ElectronSubshell electronSubshell = orbit.GetElectronSubshell(orbital.Name);

--- a/New Unity Project/Assets/Scripts/Elements/Builders/OrbitBuilder.cs
+++ b/New Unity Project/Assets/Scripts/Elements/Builders/OrbitBuilder.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using UnityEngine;
+
+public class OrbitBuilder
+{
+    private static Vector3 firstOrbitPosition = new Vector3(0.5f, 0f, 0f);
+
+    // lo que aumenta el radio (x) segun cambie de orbita
+    private static Vector3 orbitOffset = new Vector3(0.2f, 0f, 0f);
+
+    public static Orbit BuildOrbit(int electronNumber, Atom atom, GameObject electron)
+    {
+        OrbitalAndPeriodStruct orbitalAndPeriod = Orbital.GetOrbitalAndPeriod(electronNumber);
+        if(orbitalAndPeriod.Orbital != null)
+        {
+
+            Orbital orbital = orbitalAndPeriod.Orbital;
+            int period = orbitalAndPeriod.Period;
+
+            int position = Math.Min(electronNumber, orbital.MaxElectrons);
+
+            Orbit orbit = atom.GetOrbit(period);
+            if (orbit == null)
+            {
+                orbit = CreateOrbit(atom, period);
+            }
+
+            ElectronSubshell electronSubshell = orbit.GetElectronSubshell(orbital.Name);
+            if (electronSubshell == null)
+            {
+                electronSubshell = CreateElectronSubshell(orbital);
+            }
+
+            electronSubshell.AddElectron(electron);
+            orbit.ElectronSubshells.Add(electronSubshell);
+
+            return orbit;
+        }
+        return null;
+    }
+
+    private static Orbit CreateOrbit(Atom atom, int orbitNumber)
+    {
+        Vector3 orbitPosition = firstOrbitPosition + (orbitOffset * (orbitNumber - 1));
+        return atom.SpawnOrbit(orbitNumber, orbitPosition);
+    }
+
+    private static ElectronSubshell CreateElectronSubshell(Orbital orbital)
+    {
+        return new ElectronSubshell(orbital.Name, orbital.MaxElectrons);
+    }
+}

--- a/New Unity Project/Assets/Scripts/Elements/Builders/OrbitBuilder.cs.meta
+++ b/New Unity Project/Assets/Scripts/Elements/Builders/OrbitBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbc7897c16592384b9182f8124d14860
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/Elements/ElectronSubshell.cs
+++ b/New Unity Project/Assets/Scripts/Elements/ElectronSubshell.cs
@@ -1,0 +1,62 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.Linq;
+
+/**
+ * Subcapa de electrones (s, p, d, f, g, h, i)
+ * https://es.wikipedia.org/wiki/Capa_electr%C3%B3nica#Subcapas
+ */
+public class ElectronSubshell
+{
+    private string name;
+    private int maxElectrons;
+    private List<GameObject> electronList;
+
+    public string Name { get => name; set => name = value; }
+    public int MaxElectrons { get => maxElectrons; set => maxElectrons = value; }
+    public List<GameObject> ElectronList { get => electronList; }
+
+    public ElectronSubshell(string name, int maxElectrons)
+    {
+        this.name = name;
+        this.maxElectrons = maxElectrons;
+        this.electronList = new List<GameObject>();
+    }
+
+    public List<GameObject> AddElectron(GameObject electron)
+    {
+        if (!isCompleted())
+        {
+            electronList.Add(electron);
+        }
+        return electronList;
+    }
+
+    public GameObject RemoveElectron(int index)
+    {
+        if (electronList.Count > 0 && index < electronList.Count)
+        {
+            GameObject toDelete = electronList[index];
+            electronList.Remove(toDelete);
+            return toDelete;
+        }
+        return null;
+    }
+
+    public GameObject RemoveLastElectron()
+    {
+        if (electronList.Count > 0)
+        {
+            GameObject toDelete = electronList.LastOrDefault();
+            electronList.Remove(toDelete);
+            return toDelete;
+        }
+        return null;
+    }
+
+    public bool isCompleted()
+    {
+        return electronList.Count >= maxElectrons;
+    }
+}

--- a/New Unity Project/Assets/Scripts/Elements/ElectronSubshell.cs.meta
+++ b/New Unity Project/Assets/Scripts/Elements/ElectronSubshell.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b8fc61f513c943429a8b6c001666a23
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/Elements/Orbit.cs
+++ b/New Unity Project/Assets/Scripts/Elements/Orbit.cs
@@ -6,45 +6,40 @@ using UnityEditor;
 
 public class Orbit
 {
-    public int Number { get; set; }
-    public string Name { get; set; }
-    public int MaxElectrons { get; set; }
-    public Vector3 Position { get; set; }
-    public List<GameObject> ElectronList { get; }
-    public GameObject OrbitCircle { get; set; }
+    private int number;
+    private string name;
+    private int maxElectrons;
+    private Vector3 position;
+    private GameObject orbitCircle;
+    private List<ElectronSubshell> electronSubshells;
+
+    public int Number { get => number; set => number = value; }
+    public string Name { get => name; set => name = value; }
+    public int MaxElectrons { get => maxElectrons; set => maxElectrons = value; }
+    public Vector3 Position { get => position; set => position = value; }
+    public GameObject OrbitCircle { get => orbitCircle; set => orbitCircle = value; }
+    public List<ElectronSubshell> ElectronSubshells { get => electronSubshells; }
 
     public Orbit(int number, string name, int maxElectrons, Vector3 position, GameObject orbitCircle)
     {
-        Number = number;
-        Name = name;
-        MaxElectrons = maxElectrons;
-        Position = position;
-        ElectronList = new List<GameObject>();
-        OrbitCircle = orbitCircle;
+        this.number = number;
+        this.name = name;
+        this.maxElectrons = maxElectrons;
+        this.position = position;
+        this.orbitCircle = orbitCircle;
+        this.electronSubshells = new List<ElectronSubshell>();
     }
 
-    public List<GameObject> AddElectron(GameObject electron)
+    public ElectronSubshell GetElectronSubshell(string subshellName)
     {
-        if (!isCompleted())
+        foreach (ElectronSubshell electronSubshell in electronSubshells)
         {
-            ElectronList.Add(electron);
+            if (electronSubshell.Name.Equals(subshellName))
+            {
+                return electronSubshell;
+            }
         }
-        return ElectronList;
-    }
 
-    public GameObject RemoveLastElectron()
-    {
-        if (ElectronList.Count > 0)
-        {
-            GameObject toDelete = ElectronList.LastOrDefault();
-            ElectronList.Remove(toDelete);
-            return toDelete;
-        }
         return null;
-    }
-
-    public bool isCompleted()
-    {
-        return ElectronList.Count >= MaxElectrons;
     }
 }

--- a/New Unity Project/Assets/Scripts/Elements/Orbital.cs
+++ b/New Unity Project/Assets/Scripts/Elements/Orbital.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System;
+
+public class Orbital
+{
+    private string name;
+    private int maxElectrons;
+    private ArrayList periods = new ArrayList();
+
+    public string Name { get => name; }
+    public int MaxElectrons { get => maxElectrons; }
+    public ArrayList Periods { get => periods; }
+
+    private Orbital(string name, int maxElectrons, ArrayList periodos)
+    {
+        this.name = name;
+        this.maxElectrons = maxElectrons;
+        this.periods = periodos;
+    }
+
+    public static Orbital GetOrbitalS => new Orbital("s", 2, new ArrayList(new int[] { 1, 2, 3, 4, 5, 6, 7 }));
+    public static Orbital GetOrbitalP => new Orbital("p", 6, new ArrayList(new int[] { 2, 3, 4, 5, 6, 7 }));
+    public static Orbital GetOrbitalD => new Orbital("d", 10, new ArrayList(new int[] { 3, 4, 5, 6, 7 }));
+    public static Orbital GetOrbitalF => new Orbital("f", 14, new ArrayList(new int[] { 4, 5, 6, 7 }));
+    public static Orbital GetOrbitalG => new Orbital("g", 18, new ArrayList(new int[] { 5, 6, 7 }));
+    public static Orbital GetOrbitalH => new Orbital("h", 22, new ArrayList(new int[] { 6, 7 }));
+    public static Orbital GetOrbitalI => new Orbital("i", 26, new ArrayList(new int[] { 7 }));
+
+    public static List<Orbital> GetAllOrbitals => 
+        new List<Orbital>(
+            new Orbital[] 
+            {
+                GetOrbitalS,
+                GetOrbitalP,
+                GetOrbitalD,
+                GetOrbitalF,
+                GetOrbitalG,
+                GetOrbitalH,
+                GetOrbitalI
+            });
+
+    public static OrbitalAndPeriodStruct GetOrbitalAndPeriod(int electronNumber)
+    {
+        for (int i = 1; i <= 13; i++)
+        {
+            int nOrbital = Math.Min(i, 7);
+            int period = Math.Max(i - 6, 1);
+
+            while (nOrbital > 0)
+            {
+                Orbital orbital = Orbital.GetAllOrbitals[nOrbital - 1];
+                if (orbital.Periods.Contains(period))
+                {
+                    if (electronNumber <= orbital.MaxElectrons)
+                    {
+                        return new OrbitalAndPeriodStruct(period, orbital);
+                    }
+
+                    electronNumber -= orbital.MaxElectrons;
+                }
+
+                nOrbital--;
+                period++;
+            }
+        }
+        return new OrbitalAndPeriodStruct(0, null); ;
+    }
+}

--- a/New Unity Project/Assets/Scripts/Elements/Orbital.cs.meta
+++ b/New Unity Project/Assets/Scripts/Elements/Orbital.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cd20392dbc856048b937ab4a958872a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/Elements/OrbitalAndPeriodStruct.cs
+++ b/New Unity Project/Assets/Scripts/Elements/OrbitalAndPeriodStruct.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+public struct OrbitalAndPeriodStruct
+{
+    private int period;
+    private Orbital orbital;
+
+    public int Period { get => period; }
+    public Orbital Orbital { get => orbital; }
+
+    public OrbitalAndPeriodStruct(int period, Orbital orbital)
+    {
+        this.period = period;
+        this.orbital = orbital;
+    }
+}

--- a/New Unity Project/Assets/Scripts/Elements/OrbitalAndPeriodStruct.cs.meta
+++ b/New Unity Project/Assets/Scripts/Elements/OrbitalAndPeriodStruct.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66ec1e634a21b2a4b886f73fe13ce53d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/Molecule/PopulateMoleculeList.cs
+++ b/New Unity Project/Assets/Scripts/Molecule/PopulateMoleculeList.cs
@@ -62,7 +62,7 @@ public class PopulateMoleculeList : MonoBehaviour
     {
         // crea un nuevo item en la lista
         var itemList = Instantiate(moleculeItem);
-        itemList.transform.parent = content.transform;
+        itemList.transform.SetParent(content.transform);
         itemList.transform.localPosition = Vector3.zero;
         //mostrara la formula + tradicional nom
         itemList.GetComponentInChildren<TextMeshProUGUI>().text = molecule.ToStringToList;


### PR DESCRIPTION
- Se creó una clase `OrbitBuilder` encargada de agregar el electrón a la órbita correspondiente y crearla si es necesario.
- Se creó una clase `ElectronSubshell` que representa las subcapas de las órbitas de electrones (s, p, d, f, etc). La lista de electrones y los métodos correspondientes a agregar y quitar electrones que estaban en la clase `Orbit` pasaron a estar en esta clase.
- Se modificó la clase `Orbit` para que tenga una lista de `ElectronSubshell` en reemplazo de la lista de electrones. Entonces, 1 `Orbit` tiene N `ElectronSubshell` y 1 `ElectronSubshell` tiene N electrones.
- Se creó una clase `Orbital` que tiene la información y los métodos estáticos para determinar en qué período y subcapa va el electrón que se está agregando. Para poder devolver estos valores, se creó un struct `OrbitalAndPeriodStruct`.
- Se modificó la clase `Atom` para adaptarse a todo lo anterior y para que aparezcan popups a los 118 y a los 280 electrones.
- Se corrigió el warning para usar `SetParent` en vez de modificar el `parent` directamente en el script `PopulateMoleculeList`.

