### PR TITLE
disposicion-elementos-bis order objects spawn

### DIFF
--- a/New Unity Project/Assets/Scripts/Managers/AtomManager.cs
+++ b/New Unity Project/Assets/Scripts/Managers/AtomManager.cs
@@ -41,11 +41,11 @@ public class AtomManager : MonoBehaviour
     //agregar nuevo átomo al espacio de trabajo
     public void NewAtom(bool withProton)
     {
-        //intento obtener una posición disponible random
+        //intento obtener una posición disponible 
         int position;
         try
         {
-            position = positionManager.ObtainRandomPositionIndex();
+            position = positionManager.GetFirstAvailablePositionIndex();
         }
         //si no hay mas posiciones disponibles, lo loggeo y me voy
         catch(NoPositionsLeftException nple)
@@ -226,7 +226,8 @@ public class AtomManager : MonoBehaviour
             btn.interactable = status;
         }
 
-        if(positionManager.NoPositionsLeft()){
+        if(positionManager.NoPositionsLeft())
+        {
             plusAtomButton.interactable = false;
         }else{
             plusAtomButton.interactable = true;

--- a/New Unity Project/Assets/Scripts/Managers/MoleculeManager.cs
+++ b/New Unity Project/Assets/Scripts/Managers/MoleculeManager.cs
@@ -71,11 +71,11 @@ public class MoleculeManager : MonoBehaviour
     //spawnear molécula (objeto vacío donde se meten los objetos, como "Atom")
     public void SpawnMolecule(List<AtomInMolPositionData> atomsPosition, string name)
     {
-        //intento obtener una posición disponible random
+        //intento obtener una posición disponible
         int position;
         try
         {
-            position = positionManager.ObtainRandomPositionIndex();
+            position = positionManager.GetFirstAvailablePositionIndex();
         }
         //si no hay mas posiciones disponibles, lo loggeo y me voy
         catch (NoPositionsLeftException nple)

--- a/New Unity Project/Assets/Scripts/Managers/PositionManager.cs
+++ b/New Unity Project/Assets/Scripts/Managers/PositionManager.cs
@@ -84,81 +84,7 @@ public class PositionManager
         Positions.Add(new Vector3(-12.5f, 5, 4));
         Positions.Add(new Vector3(12.5f, 7, 4));
         Positions.Add(new Vector3(-12.5f, 7, 4));
-        //Z=8
-        Positions.Add(new Vector3(-2.5f, 1, 8));
-        Positions.Add(new Vector3(2.5f, 1, 8));
-        Positions.Add(new Vector3(-2.5f, 3, 8));
-        Positions.Add(new Vector3(2.5f, 3, 8));
-        Positions.Add(new Vector3(2.5f, 5, 8));
-        Positions.Add(new Vector3(-2.5f, 5, 8));
-        Positions.Add(new Vector3(2.5f, 7, 8));
-        Positions.Add(new Vector3(-2.5f, 7, 8));
-        Positions.Add(new Vector3(-7.5f, 1, 8));
-        Positions.Add(new Vector3(7.5f, 1, 8));
-        Positions.Add(new Vector3(-7.5f, 3, 8));
-        Positions.Add(new Vector3(7.5f, 3, 8));
-        Positions.Add(new Vector3(7.5f, 5, 8));
-        Positions.Add(new Vector3(-7.5f, 5, 8));
-        Positions.Add(new Vector3(7.5f, 7, 8));
-        Positions.Add(new Vector3(-7.5f, 7, 8));
-        Positions.Add(new Vector3(-12.5f, 1, 8));
-        Positions.Add(new Vector3(12.5f, 1, 8));
-        Positions.Add(new Vector3(-12.5f, 3, 8));
-        Positions.Add(new Vector3(12.5f, 3, 8));
-        Positions.Add(new Vector3(12.5f, 5, 8));
-        Positions.Add(new Vector3(-12.5f, 5, 8));
-        Positions.Add(new Vector3(12.5f, 7, 8));
-        Positions.Add(new Vector3(-12.5f, 7, 8));
-        //Z=12
-        Positions.Add(new Vector3(-2.5f, 1, 12));
-        Positions.Add(new Vector3(2.5f, 1, 12));
-        Positions.Add(new Vector3(-2.5f, 3, 12));
-        Positions.Add(new Vector3(2.5f, 3, 12));
-        Positions.Add(new Vector3(2.5f, 5, 12));
-        Positions.Add(new Vector3(-2.5f, 5, 12));
-        Positions.Add(new Vector3(2.5f, 7, 12));
-        Positions.Add(new Vector3(-2.5f, 7, 12));
-        Positions.Add(new Vector3(-7.5f, 1, 12));
-        Positions.Add(new Vector3(7.5f, 1, 12));
-        Positions.Add(new Vector3(-7.5f, 3, 12));
-        Positions.Add(new Vector3(7.5f, 3, 12));
-        Positions.Add(new Vector3(7.5f, 5, 12));
-        Positions.Add(new Vector3(-7.5f, 5, 12));
-        Positions.Add(new Vector3(7.5f, 7, 12));
-        Positions.Add(new Vector3(-7.5f, 7, 12));
-        Positions.Add(new Vector3(-12.5f, 1, 12));
-        Positions.Add(new Vector3(12.5f, 1, 12));
-        Positions.Add(new Vector3(-12.5f, 3, 12));
-        Positions.Add(new Vector3(12.5f, 3, 12));
-        Positions.Add(new Vector3(12.5f, 5, 12));
-        Positions.Add(new Vector3(-12.5f, 5, 12));
-        Positions.Add(new Vector3(12.5f, 7, 12));
-        Positions.Add(new Vector3(-12.5f, 7, 12));
-        //Z=16
-        Positions.Add(new Vector3(-2.5f, 1, 16));
-        Positions.Add(new Vector3(2.5f, 1, 16));
-        Positions.Add(new Vector3(-2.5f, 3, 16));
-        Positions.Add(new Vector3(2.5f, 3, 16));
-        Positions.Add(new Vector3(2.5f, 5, 16));
-        Positions.Add(new Vector3(-2.5f, 5, 16));
-        Positions.Add(new Vector3(2.5f, 7, 16));
-        Positions.Add(new Vector3(-2.5f, 7, 16));
-        Positions.Add(new Vector3(-7.5f, 1, 16));
-        Positions.Add(new Vector3(7.5f, 1, 16));
-        Positions.Add(new Vector3(-7.5f, 3, 16));
-        Positions.Add(new Vector3(7.5f, 3, 16));
-        Positions.Add(new Vector3(7.5f, 5, 16));
-        Positions.Add(new Vector3(-7.5f, 5, 16));
-        Positions.Add(new Vector3(7.5f, 7, 16));
-        Positions.Add(new Vector3(-7.5f, 7, 16));
-        Positions.Add(new Vector3(-12.5f, 1, 16));
-        Positions.Add(new Vector3(12.5f, 1, 16));
-        Positions.Add(new Vector3(-12.5f, 3, 16));
-        Positions.Add(new Vector3(12.5f, 3, 16));
-        Positions.Add(new Vector3(12.5f, 5, 16));
-        Positions.Add(new Vector3(-12.5f, 5, 16));
-        Positions.Add(new Vector3(12.5f, 7, 16));
-        Positions.Add(new Vector3(-12.5f, 7, 16));
+
         //Z=-4
         Positions.Add(new Vector3(-2.5f, 1, -4));
         Positions.Add(new Vector3(2.5f, 1, -4));
@@ -184,6 +110,33 @@ public class PositionManager
         Positions.Add(new Vector3(-12.5f, 5, -4));
         Positions.Add(new Vector3(12.5f, 7, -4));
         Positions.Add(new Vector3(-12.5f, 7, -4));
+
+        //Z=8
+        Positions.Add(new Vector3(-2.5f, 1, 8));
+        Positions.Add(new Vector3(2.5f, 1, 8));
+        Positions.Add(new Vector3(-2.5f, 3, 8));
+        Positions.Add(new Vector3(2.5f, 3, 8));
+        Positions.Add(new Vector3(2.5f, 5, 8));
+        Positions.Add(new Vector3(-2.5f, 5, 8));
+        Positions.Add(new Vector3(2.5f, 7, 8));
+        Positions.Add(new Vector3(-2.5f, 7, 8));
+        Positions.Add(new Vector3(-7.5f, 1, 8));
+        Positions.Add(new Vector3(7.5f, 1, 8));
+        Positions.Add(new Vector3(-7.5f, 3, 8));
+        Positions.Add(new Vector3(7.5f, 3, 8));
+        Positions.Add(new Vector3(7.5f, 5, 8));
+        Positions.Add(new Vector3(-7.5f, 5, 8));
+        Positions.Add(new Vector3(7.5f, 7, 8));
+        Positions.Add(new Vector3(-7.5f, 7, 8));
+        Positions.Add(new Vector3(-12.5f, 1, 8));
+        Positions.Add(new Vector3(12.5f, 1, 8));
+        Positions.Add(new Vector3(-12.5f, 3, 8));
+        Positions.Add(new Vector3(12.5f, 3, 8));
+        Positions.Add(new Vector3(12.5f, 5, 8));
+        Positions.Add(new Vector3(-12.5f, 5, 8));
+        Positions.Add(new Vector3(12.5f, 7, 8));
+        Positions.Add(new Vector3(-12.5f, 7, 8));
+
         //Z=-8
         Positions.Add(new Vector3(-2.5f, 1, -8));
         Positions.Add(new Vector3(2.5f, 1, -8));
@@ -209,6 +162,33 @@ public class PositionManager
         Positions.Add(new Vector3(-12.5f, 5, -8));
         Positions.Add(new Vector3(12.5f, 7, -8));
         Positions.Add(new Vector3(-12.5f, 7, -8));
+
+        //Z=12
+        Positions.Add(new Vector3(-2.5f, 1, 12));
+        Positions.Add(new Vector3(2.5f, 1, 12));
+        Positions.Add(new Vector3(-2.5f, 3, 12));
+        Positions.Add(new Vector3(2.5f, 3, 12));
+        Positions.Add(new Vector3(2.5f, 5, 12));
+        Positions.Add(new Vector3(-2.5f, 5, 12));
+        Positions.Add(new Vector3(2.5f, 7, 12));
+        Positions.Add(new Vector3(-2.5f, 7, 12));
+        Positions.Add(new Vector3(-7.5f, 1, 12));
+        Positions.Add(new Vector3(7.5f, 1, 12));
+        Positions.Add(new Vector3(-7.5f, 3, 12));
+        Positions.Add(new Vector3(7.5f, 3, 12));
+        Positions.Add(new Vector3(7.5f, 5, 12));
+        Positions.Add(new Vector3(-7.5f, 5, 12));
+        Positions.Add(new Vector3(7.5f, 7, 12));
+        Positions.Add(new Vector3(-7.5f, 7, 12));
+        Positions.Add(new Vector3(-12.5f, 1, 12));
+        Positions.Add(new Vector3(12.5f, 1, 12));
+        Positions.Add(new Vector3(-12.5f, 3, 12));
+        Positions.Add(new Vector3(12.5f, 3, 12));
+        Positions.Add(new Vector3(12.5f, 5, 12));
+        Positions.Add(new Vector3(-12.5f, 5, 12));
+        Positions.Add(new Vector3(12.5f, 7, 12));
+        Positions.Add(new Vector3(-12.5f, 7, 12));
+
         //Z=-12
         Positions.Add(new Vector3(-2.5f, 1, -12));
         Positions.Add(new Vector3(2.5f, 1, -12));
@@ -234,6 +214,33 @@ public class PositionManager
         Positions.Add(new Vector3(-12.5f, 5, -12));
         Positions.Add(new Vector3(12.5f, 7, -12));
         Positions.Add(new Vector3(-12.5f, 7, -12));
+
+        //Z=16
+        Positions.Add(new Vector3(-2.5f, 1, 16));
+        Positions.Add(new Vector3(2.5f, 1, 16));
+        Positions.Add(new Vector3(-2.5f, 3, 16));
+        Positions.Add(new Vector3(2.5f, 3, 16));
+        Positions.Add(new Vector3(2.5f, 5, 16));
+        Positions.Add(new Vector3(-2.5f, 5, 16));
+        Positions.Add(new Vector3(2.5f, 7, 16));
+        Positions.Add(new Vector3(-2.5f, 7, 16));
+        Positions.Add(new Vector3(-7.5f, 1, 16));
+        Positions.Add(new Vector3(7.5f, 1, 16));
+        Positions.Add(new Vector3(-7.5f, 3, 16));
+        Positions.Add(new Vector3(7.5f, 3, 16));
+        Positions.Add(new Vector3(7.5f, 5, 16));
+        Positions.Add(new Vector3(-7.5f, 5, 16));
+        Positions.Add(new Vector3(7.5f, 7, 16));
+        Positions.Add(new Vector3(-7.5f, 7, 16));
+        Positions.Add(new Vector3(-12.5f, 1, 16));
+        Positions.Add(new Vector3(12.5f, 1, 16));
+        Positions.Add(new Vector3(-12.5f, 3, 16));
+        Positions.Add(new Vector3(12.5f, 3, 16));
+        Positions.Add(new Vector3(12.5f, 5, 16));
+        Positions.Add(new Vector3(-12.5f, 5, 16));
+        Positions.Add(new Vector3(12.5f, 7, 16));
+        Positions.Add(new Vector3(-12.5f, 7, 16));
+        
         //Z=-16
         Positions.Add(new Vector3(-2.5f, 1, -16));
         Positions.Add(new Vector3(2.5f, 1, -16));
@@ -268,26 +275,21 @@ public class PositionManager
     }
 #endregion
 
-    //obtengo una posición random en el plano
-    public int ObtainRandomPositionIndex()
+    //obtengo la proxima posicion disponible en el plano
+    public int GetFirstAvailablePositionIndex()
     {
-        //si no hay mas disponibles tiro exception
-        if (NoPositionsLeft())
+        int index = 0;
+        foreach (bool available in AvailablePositions)
         {
-            Debug.Log("Arrojo excepcion: No hay más posiciones disponibles");
-            throw (new NoPositionsLeftException("No hay más posiciones disponibles"));
-        }
-        int positions = AvailablePositions.Count;
-        while (true)
-        {
-            //obtengo posición random hasta encontrar una libre
-            int randomIndex = Random.Range(0, positions);
-            if (AvailablePositions[randomIndex])
-            {
-                AvailablePositions[randomIndex] = false;
-                return randomIndex;
+            if (available) {
+                AvailablePositions[index] = false;
+                return index; 
             }
+            index++;
         }
+
+        Debug.Log("No hay más posiciones disponibles");
+        throw (new NoPositionsLeftException("No hay más posiciones disponibles"));
     }
 
     //chequeo si hay posiciones disponibles


### PR DESCRIPTION
- Se cambia el método `ObtainRandomPositionIndex()` del `PositionManager` por `GetFirstAvailablePositionIndex()`, que ahora devuelve la primer posición disponible desde el centro del entorno en vez de una position random.
- Se ordena la lista de posiciones para que los spawns sucedan desde el centro hacia afuera